### PR TITLE
Adding timeout to log stream

### DIFF
--- a/client.go
+++ b/client.go
@@ -535,11 +535,25 @@ func (c *Client) stream(method, path string, streamOptions streamOptions) error 
 			}
 		}
 	} else {
+		keepAlive := make(chan bool, 1)
+		go func() {
+			if streamOptions.timeout > 0 {
+				select {
+				case <-time.After(streamOptions.timeout):
+					resp.Body.Close()
+				case <-keepAlive:
+				}
+			}
+		}()
 		if streamOptions.setRawTerminal {
 			_, err = io.Copy(streamOptions.stdout, resp.Body)
 		} else {
 			_, err = stdcopy.StdCopy(streamOptions.stdout, streamOptions.stderr, resp.Body)
 		}
+		go func() {
+			keepAlive <- true
+			close(keepAlive)
+		}()
 		return err
 	}
 	return nil

--- a/container.go
+++ b/container.go
@@ -972,6 +972,7 @@ func (c *Client) Logs(opts LogsOptions) error {
 		setRawTerminal: opts.RawTerminal,
 		stdout:         opts.OutputStream,
 		stderr:         opts.ErrorStream,
+		timeout:        30 * time.Minute,
 	})
 }
 

--- a/container.go
+++ b/container.go
@@ -972,7 +972,7 @@ func (c *Client) Logs(opts LogsOptions) error {
 		setRawTerminal: opts.RawTerminal,
 		stdout:         opts.OutputStream,
 		stderr:         opts.ErrorStream,
-		timeout:        30 * time.Minute,
+		timeout:        120 * time.Minute,
 	})
 }
 


### PR DESCRIPTION
Performs a simple keepAlive timeout closing the log stream should the timeout be reached
